### PR TITLE
Add Oakley HSTN Meta detection; fix Snap company ID in CSV

### DIFF
--- a/Android/app/src/main/java/ch/pocketpc/nearbyglasses/model/DetectionEvent.kt
+++ b/Android/app/src/main/java/ch/pocketpc/nearbyglasses/model/DetectionEvent.kt
@@ -52,7 +52,7 @@ data class DetectionEvent(
         // Meta Platforms, Inc. (formerly Facebook)
         const val META_COMPANY_ID1 = 0x01AB
         const val META_COMPANY_ID2 = 0x058E
-        // EssilorLuxottica - needs more verification, but OAKLEY and some newer Meta models likely have that
+        // EssilorLuxottica (Luxottica Group S.p.A.) - parent of Oakley; confirmed on Oakley HSTN Meta via name match
         const val ESSILOR_COMPANY_ID = 0x0D53
         //Snap (Snapchat) Spectacles
         const val SNAP_COMPANY_ID = 0x03C2
@@ -126,6 +126,9 @@ data class DetectionEvent(
                     nameLower.contains("heycyan") -> reasons.add(
                         context.getString(R.string.reason_name_contains,"HeyCyan")
                     ) //Nilox Smart AI Glasses and alike
+                    nameLower.contains("oakley") -> reasons.add(
+                        context.getString(R.string.reason_name_contains,"Oakley")
+                    ) //Oakley HSTN Meta (e.g. "Oakley Meta 099H")
 
                     else -> {} // do nothing
                 }

--- a/Android/app/src/main/java/ch/pocketpc/nearbyglasses/scanner/BluetoothScanner.kt
+++ b/Android/app/src/main/java/ch/pocketpc/nearbyglasses/scanner/BluetoothScanner.kt
@@ -32,7 +32,7 @@ class BluetoothScanner(
     private val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
     private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
     private var bleScanner: BluetoothLeScanner? = null
-    
+
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning
 
@@ -93,16 +93,13 @@ class BluetoothScanner(
             bleScanner?.startScan(null, scanSettings, scanCallback)
             _isScanning.value = true
             if (debugEnabled) {
-                //Log.i(TAG, "BLE scanning started. RSSI threshold=$rssiThreshold, mode=LOW_LATENCY")
                 Log.i(TAG, context.getString(R.string.dbg_ble_started_verbose, rssiThreshold))
             } else {
-                //Log.i(TAG, "BLE scanning started with RSSI threshold: $rssiThreshold dBm")
                 Log.i(TAG, context.getString(R.string.dbg_ble_started_simple, rssiThreshold))
             }
             return true
         } catch (e: Exception) {
-            //Log.e(TAG, "Error starting BLE scan", e)
-            Log.e(TAG, context.getString(R.string.dbg_ble_start_error),e)
+            Log.e(TAG, context.getString(R.string.dbg_ble_start_error), e)
             return false
         }
     }
@@ -116,11 +113,9 @@ class BluetoothScanner(
         try {
             bleScanner?.stopScan(scanCallback)
             _isScanning.value = false
-            //Log.i(TAG, "BLE scanning stopped")
             Log.i(TAG, context.getString(R.string.dbg_ble_stopped))
         } catch (e: Exception) {
-            //Log.e(TAG, "Error stopping BLE scan", e)
-            Log.e(TAG, context.getString(R.string.dbg_ble_stop_error),e)
+            Log.e(TAG, context.getString(R.string.dbg_ble_stop_error), e)
         }
     }
     private var lastUiDebugAt = 0L

--- a/iOS/NearbyGlasses/BLEScanner.swift
+++ b/iOS/NearbyGlasses/BLEScanner.swift
@@ -32,6 +32,8 @@ struct SmartGlassesHeuristics {
             if name.contains("rayban") { reasons.append(l10n.text("reason_name_contains", "rayban")) }
             if name.contains("ray-ban") { reasons.append(l10n.text("reason_name_contains", "ray-ban")) }
             if name.contains("ray ban") { reasons.append(l10n.text("reason_name_contains", "ray ban")) }
+            if name.contains("heycyan") { reasons.append(l10n.text("reason_name_contains", "HeyCyan")) }
+            if name.contains("oakley") { reasons.append(l10n.text("reason_name_contains", "Oakley")) } // Oakley HSTN Meta (e.g. "Oakley Meta 099H")
         }
 
         return reasons

--- a/smart_glasses_identifiers.csv
+++ b/smart_glasses_identifiers.csv
@@ -3,7 +3,8 @@
 Product                , identification                                     , source(s)                                                              , notes
 Meta/RayBan            , manufacturer_ID=0x01AB                             , [BT SIG](https://www.bluetooth.com/specifications/assigned-numbers/)   , 
 Meta/RayBan            , manufacturer_ID=0x058E                             , [BT SIG](https://www.bluetooth.com/specifications/assigned-numbers/)   ,
-Snap                   , manufacturer_ID=0x0D53                             , [BT SIG](https://www.bluetooth.com/specifications/assigned-numbers/)   ,
+Snap                   , manufacturer_ID=0x03C2                             , [BT SIG](https://www.bluetooth.com/specifications/assigned-numbers/)   ,
+Oakley HSTN Meta       , manufacturer_ID=0x0D53                             , [BT SIG](https://www.bluetooth.com/specifications/assigned-numbers/)   , "Luxottica Group S.p.A. (Oakley parent); also triggers via 0x01AB/0x058E (Meta firmware); device name format: 'Oakley Meta XXXH'; confirmed on Oakley HSTN (productRegistry=265, codename hammerhead)"
 Nilox Smart AI Glasses , primary_UUID=7905FFF0-B5CE-4E99-A40F-4B1E122D00D0  , [HeyCyan SDK](https://github.com/ebowwa/HeyCyanSmartGlassesSDK)        , "There seems to be no fixed manufacturer ID"
 .                      , device_name=HeyCyan-WXYZ                           , [HeyCyan SDK](https://github.com/ebowwa/HeyCyanSmartGlassesSDK)        , "There seems to be no fixed manufacturer ID"
 Rogbird VisionPro      , manufacturer_ID=0x05D6                             , [BT SIG](https://www.bluetooth.com/specifications/assigned-numbers/)   , "Zhuhai Jieli Technology Co., but the VisionPro uses the Jieli JL7018 Bluetooth chipset"


### PR DESCRIPTION
## Summary

This PR adds detection support for the **Oakley HSTN Meta** smart glasses, tested on real hardware, and fixes a wrong company ID entry for Snap in the CSV.

### Changes

- **`DetectionEvent.kt`**: Add `"oakley"` name match — the device advertises as `"Oakley Meta 099H"`. Clarify the `ESSILOR_COMPANY_ID` comment: Luxottica Group S.p.A. (registered as `0x0D53` in BT SIG) is Oakley's parent company.
- **`BLEScanner.swift`** (iOS): Add `"oakley"` name match for parity with Android. Also add missing `"heycyan"` name match (present in Android but absent in iOS).
- **`smart_glasses_identifiers.csv`**: Fix Snap entry — it was incorrectly listed as `0x0D53` (Luxottica); correct value is `0x03C2` (Snap Inc.). Add new row for Oakley HSTN Meta with `0x0D53` and a note that `0x01AB`/`0x058E` also trigger (same Meta firmware as Ray-Ban Gen 2).

### Hardware evidence

Tested on a real **Oakley HSTN Meta** unit (internal codename `hammerhead`, `productRegistry=265`). During the BLE advertising window, detection fires on both signals simultaneously:

```
ADV addr=48:6F:B1:EB:5D:E4 name=Oakley Meta 099H rssi=-51 companyId=0x01AB
→ Meta Company ID (0x01AB), Device name contains 'Oakley'
```

### Known limitation: detection window

BLE advertising is only emitted while the device is **disconnected or reconnecting** to its paired phone. Once the connection is established, the device stops advertising — this is a BLE protocol-level behaviour, not specific to this app or device. In practice, detection fires every time the user brings the glasses close to their phone (reconnection event).

This limitation applies equally to Ray-Ban Meta and all other BLE-only devices in the project's detection list. It is worth noting in the project documentation for user awareness.